### PR TITLE
Decoding issue fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Installing the package on Windows will result in a decoding error.

Specifying encoding for README.md fixes the issue, without any adverse affects on Linux installation. 